### PR TITLE
cli: Add --databases parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ One can specify an alternative configuration file:
 #> swiftbackmeup --conf /path/to/conf.yml
 ```
 
+One can limit the databases that will be backedup :
+
+```
+#> swiftbackmeup --databases db1,mydb
+```
+
 ## Modes
 
 Modes are equivalent to tag the backup needs to be subscribed to.

--- a/swiftbackmeup/parser.py
+++ b/swiftbackmeup/parser.py
@@ -24,5 +24,38 @@ def parse():
         help='Mode under which the script will be run')
     parser.add_argument('--conf',
         help='Path to configuration file')
+    parser.add_argument('--databases',
+        action='append',
+        nargs='*',
+        help='Databases list to apply action to')
 
-    return parser.parse_args()
+    options = parser.parse_args()
+    normalize_databases_parameter(options)
+
+    return options
+
+
+def normalize_databases_parameter(options):
+    """The databases parameters can have differents form based on how it
+       was passed as an input
+
+       swiftbackmeup --databases db1,db2
+       swiftbackmeup --databases db1 db2
+       swiftbackmeup --databases db1 --databases db2
+
+       This method aims to provide a plain array witch each element being
+       a database itself
+    """
+
+    if not isinstance(options.databases, list):
+        return
+
+    final_dbs = []
+    for dbs in options.databases:
+        for db in dbs:
+            if ',' in db:
+                final_dbs += db.split(',')
+            else:
+                final_dbs.append(db)
+
+    options.databases = final_dbs

--- a/swiftbackmeup/shell.py
+++ b/swiftbackmeup/shell.py
@@ -39,6 +39,17 @@ def main():
     backups = configuration.expand_configuration(global_configuration)
     modes = global_configuration.get('mode')
 
+    # If --databases has been specified, run the command only to
+    # a subset of the backups listed in the configuration file.
+    #
+    if isinstance(options.databases, list):
+        tmp_backups = []
+        for backup in backups:
+            if backup['database'] in options.databases:
+                tmp_backups.append(backup)
+        backups = tmp_backups
+
+
     for backup in backups:
         if options.mode in backup['subscriptions']:
             backup['filename'] = utils.build_filename(backup,


### PR DESCRIPTION
The --databases parameter allows one to limit the scope of
the databases that will be taken in consideration when doing
backups.

swiftbackmeup --databases db1
swiftbackmeup --databases db1,db2
swiftbackmeup --databases db1 db2
swiftbackmeup --databases db1 --databases db2
