### PR TITLE
Store: Add get() method to prepare restore()

### DIFF
--- a/swiftbackmeup/exceptions.py
+++ b/swiftbackmeup/exceptions.py
@@ -21,3 +21,10 @@ class ConfigurationExceptions(Exception):
     def __init__(self, message):
         print message
         sys.exit(1)
+
+
+class StoreExceptions(Exception):
+
+    def __init__(self, message):
+        print message
+        sys.exit(1)

--- a/swiftbackmeup/stores/__init__.py
+++ b/swiftbackmeup/stores/__init__.py
@@ -20,6 +20,10 @@ class Store(object):
         pass
 
 
+    def get(self):
+        pass
+
+
     def list(self):
         pass
 


### PR DESCRIPTION
A get() method has been added to the Store interface so the backup
could be retrieved before being restored.
