### PR TITLE
swift: Add region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The below section aims to explain every parameter of the configuration file
 | os_username         | global         | None    | OpenStack Username                                                |
 | os_password         | global         | None    | OpenStack Password                                                |
 | os_tenant_name      | global         | None    | OpenStack Tenant Name                                             |
+| os_region_name      | global         | None    | OpenStack Region Name                                             |
 | os_auth_url         | global         | None    | OpenStack Authentication URL                                      |
 | store_type          | global, backup | None    | The store type to upload backup to (available: swift)             |
 | create_container    | global, backup | True    | If the container does not exist, should it be created             |

--- a/swiftbackmeup/configuration.py
+++ b/swiftbackmeup/configuration.py
@@ -19,9 +19,9 @@ import os
 import yaml
 
 _FIELDS = ['os_username', 'os_password', 'os_tenant_name', 'os_auth_url',
-           'create_container', 'purge_container', 'swift_container',
-           'swift_pseudo_folder', 'output_directory', 'clean_local_copy',
-           'type', 'user', 'password', 'host', 'port',
+           'os_region_name', 'create_container', 'purge_container',
+           'swift_container', 'swift_pseudo_folder', 'output_directory',
+           'clean_local_copy', 'type', 'user', 'password', 'host', 'port',
            'store_type']
 
 
@@ -85,10 +85,12 @@ def verify_mandatory_parameter(configuration):
     os_username = configuration.get('os_username', os.getenv('OS_USERNAME'))
     os_password = configuration.get('os_password',os.getenv('OS_PASSWORD'))
     os_tenant_name = configuration.get('os_tenant_name', os.getenv('OS_TENANT_NAME'))
+    os_region_name = configuration.get('os_region_name', os.getenv('OS_REGION_NAME'))
     os_auth_url = configuration.get('os_auth_url', os.getenv('OS_AUTH_URL'))
 
-    if not (os_username and os_password and os_tenant_name and os_auth_url):
-        raise exceptions.ConfigurationExceptions('One of the following parameter is not configured: os_username, os_password, os_tenant_name, os_auth_url')
+    if not (os_username and os_password and os_tenant_name and
+            os_auth_url and os_region_name):
+        raise exceptions.ConfigurationExceptions('One of the following parameter is not configured: os_username, os_password, os_tenant_name, os_auth_url, os_region_name')
 
     if (len([1 for backup in configuration['backups'] if 'swift_container' in backup]) != len(configuration['backups'])) and 'swift_container' not in configuration:
         raise exceptions.ConfigurationExceptions('swift_container has not been specified for every backups and no global setting has been set')

--- a/swiftbackmeup/stores/swift.py
+++ b/swiftbackmeup/stores/swift.py
@@ -31,6 +31,9 @@ class Swift(stores.Store):
                                        os.getenv('OS_TENANT_NAME'))
         self.os_auth_url = conf.get('os_auth_url',
                                     os.getenv('OS_AUTH_URL'))
+        self.os_options = dict()
+        self.os_options['region_name'] = conf.get('os_region_name',
+                                                  os.getenv('OS_REGION_NAME'))
         self.connection = self.get_connection()
 
 
@@ -39,6 +42,7 @@ class Swift(stores.Store):
                                              user=self.os_username,
                                              key=self.os_password,
                                              tenant_name=self.os_tenant_name,
+                                             os_options=self.os_options,
                                              authurl=self.os_auth_url)
 
 


### PR DESCRIPTION
When using a public openstack cloud with multiple regions we need to
specify the region name to be sure to store the object-storage data
in the same region than the instances.